### PR TITLE
Fix SSLException sent by the server

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ipc/Client.java
@@ -1005,7 +1005,7 @@ public class Client implements AutoCloseable {
       // before all messages are sent.
       final DataOutputStream out = streams.out;
       synchronized (out) {
-
+        
         out.write(RpcConstants.HEADER.array());
         out.write(RpcConstants.CURRENT_VERSION);
         out.write(serviceClass);
@@ -1528,7 +1528,7 @@ public class Client implements AutoCloseable {
         if (call.error instanceof RemoteException) {
           call.error.fillInStackTrace();
           throw call.error;
-        } else if (call.error.getCause() instanceof SSLException) {
+        } else if (call.error instanceof SSLException) {
           LOG.error("Connection " + connection.getName() + " encountered TLS error", call.error.getCause());
           throw new SSLException(call.error.getMessage());
         } else { // local exception

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/HopsSSLTestUtils.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/ssl/HopsSSLTestUtils.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -103,6 +104,8 @@ public class HopsSSLTestUtils {
         conf.setBoolean(CommonConfigurationKeysPublic.IPC_SERVER_SSL_ENABLED, true);
         conf.set(SSLFactory.SSL_ENABLED_PROTOCOLS, "TLSv1.2,TLSv1.1,TLSv1");
         conf.set(SSLFactory.SSL_HOSTNAME_VERIFIER_KEY, "ALLOW_ALL");
+        String user = UserGroupInformation.getCurrentUser().getUserName();
+        conf.set(ProxyUsers.CONF_HADOOP_PROXYUSER + "." + user, "*");
 
         Configuration sslServerConf = KeyStoreTestUtil.createServerSSLConfig(serverKeyStore.toString(),
                 passwd, passwd, serverTrustStore.toString(), passwd, "");

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-tests/src/test/java/org/apache/hadoop/yarn/server/TestYarnSSLServer.java
@@ -23,12 +23,15 @@ import org.apache.hadoop.net.HopsSSLSocketFactory;
 import org.apache.hadoop.security.ssl.HopsSSLTestUtils;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.yarn.api.ApplicationClientProtocol;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationReportRequest;
+import org.apache.hadoop.yarn.api.protocolrecords.GetApplicationsRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterNodesRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetClusterNodesResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationRequest;
 import org.apache.hadoop.yarn.api.protocolrecords.GetNewApplicationResponse;
 import org.apache.hadoop.yarn.api.protocolrecords.SubmitApplicationRequest;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.LocalResource;
@@ -44,6 +47,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.Records;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,6 +55,7 @@ import org.junit.runners.Parameterized;
 import javax.net.ssl.SSLException;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -163,6 +168,18 @@ public class TestYarnSSLServer extends HopsSSLTestUtils {
         assertNotNull(newAppRes);
         LOG.debug("I have gotten the new application");
         
+        List<ApplicationReport> appsReport = acClient.getApplications(
+            GetApplicationsRequest.newInstance()).getApplicationList();
+        boolean found = false;
+        
+        for (ApplicationReport appRep : appsReport) {
+            if (appRep.getApplicationId().equals(appCtx.getApplicationId())) {
+                found = true;
+                break;
+            }
+        }
+        
+        assertTrue(found);
         TimeUnit.SECONDS.sleep(10);
     }
     


### PR DESCRIPTION
SSLException is no longer encapsulated as a cause in the serialized error sent by server to the client